### PR TITLE
feat(pipeline): split Build and Run steps from puppeteer

### DIFF
--- a/.github/workflows/bamboohr-puppeteer.yml
+++ b/.github/workflows/bamboohr-puppeteer.yml
@@ -23,11 +23,16 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   eslint: true
                   prettier: true
+            - name: Build
+              uses: ianwalter/puppeteer@v2.0.0
+              with:
+                  args: yarn build
             - name: Puppeteer
+              if: ${{ github.event_name != 'push' }}
               uses: ianwalter/puppeteer@v2.0.0
               env:
                   COMPANY: ${{ secrets.COMPANY_BAMBOOHR }}
                   USER: ${{ secrets.USER_BAMBOOHR }}
                   PASSWORD: ${{ secrets.PASSWORD_BAMBOOHR }}
               with:
-                  args: yarn run start
+                  args: yarn start

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "build": "tsc",
         "lint": "eslint '*/**/*.{js,ts,json}' --quiet",
         "lint:fix": "npm run lint -- --fix",
-        "start": "npm run build; node --unhandled-rejections=strict ./dist/index.js",
+        "start": "node --unhandled-rejections=strict ./dist/index.js",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- Split `Build` and `Run` steps of Puppeteer in Pipeline
- Added condition to `Run` step to only run when is not a `push` event (when `labeled` or `schedule`)

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix #88 
Fix #92 
